### PR TITLE
get rid of ObjectAttributeValue

### DIFF
--- a/kotlin-insight-client/kotlin-insight-client-api/src/main/kotlin/com/linkedplanet/kotlininsightclient/api/error/InsightClientError.kt
+++ b/kotlin-insight-client/kotlin-insight-client-api/src/main/kotlin/com/linkedplanet/kotlininsightclient/api/error/InsightClientError.kt
@@ -24,7 +24,7 @@ package com.linkedplanet.kotlininsightclient.api.error
 import arrow.core.Either
 import com.linkedplanet.kotlininsightclient.api.model.InsightObjectId
 import com.linkedplanet.kotlininsightclient.api.model.InsightObjectTypeId
-import com.linkedplanet.kotlininsightclient.api.model.ObjectAttributeValue
+import com.linkedplanet.kotlininsightclient.api.model.InsightAttribute
 
 @Suppress("unused")
 sealed class InsightClientError(
@@ -40,7 +40,7 @@ sealed class InsightClientError(
         fun fromException(e: Throwable): InsightClientError =
             ExceptionInsightClientError(e.message ?: "Interner Fehler", e.stackTraceToString())
 
-        fun internalError(message: String): Either<InsightClientError, ObjectAttributeValue> =
+        fun internalError(message: String): Either<InsightClientError, InsightAttribute> =
             InternalInsightClientError("Interner Fehler", message).asEither()
 
     }

--- a/kotlin-insight-client/kotlin-insight-client-api/src/main/kotlin/com/linkedplanet/kotlininsightclient/api/impl/AbstractNameMappedRepository.kt
+++ b/kotlin-insight-client/kotlin-insight-client-api/src/main/kotlin/com/linkedplanet/kotlininsightclient/api/impl/AbstractNameMappedRepository.kt
@@ -28,14 +28,13 @@ import com.linkedplanet.kotlininsightclient.api.error.InvalidArgumentInsightClie
 import com.linkedplanet.kotlininsightclient.api.error.asEither
 import com.linkedplanet.kotlininsightclient.api.interfaces.InsightObjectTypeOperator
 import com.linkedplanet.kotlininsightclient.api.interfaces.InsightSchemaOperator
-import com.linkedplanet.kotlininsightclient.api.model.InsightAttribute
 import com.linkedplanet.kotlininsightclient.api.model.InsightAttribute.Companion.toReferences
 import com.linkedplanet.kotlininsightclient.api.model.InsightAttribute.Companion.toSelectValues
 import com.linkedplanet.kotlininsightclient.api.model.InsightAttribute.Companion.toValue
 import com.linkedplanet.kotlininsightclient.api.model.InsightObject
 import com.linkedplanet.kotlininsightclient.api.model.InsightObjectId
 import com.linkedplanet.kotlininsightclient.api.model.InsightObjectTypeId
-import com.linkedplanet.kotlininsightclient.api.model.ObjectAttributeValue
+import com.linkedplanet.kotlininsightclient.api.model.InsightAttribute
 import com.linkedplanet.kotlininsightclient.api.model.ObjectTypeSchema
 import com.linkedplanet.kotlininsightclient.api.model.ObjectTypeSchemaAttribute
 import com.linkedplanet.kotlininsightclient.api.model.getAttribute
@@ -141,7 +140,7 @@ abstract class AbstractNameMappedRepository<DomainType : Any>(
             val mappedValue = when {
                 attribute?.isReference() == true -> referenceAttributeToValue(attribute)
                 attribute == null -> null
-                else -> defaultAttributeToValue(attribute.value, param.type).bind()
+                else -> defaultAttributeToValue(attribute, param.type).bind()
             }
             mappedValue
 
@@ -151,22 +150,22 @@ abstract class AbstractNameMappedRepository<DomainType : Any>(
     }
 
     private suspend fun defaultAttributeToValue(
-        value: ObjectAttributeValue,
+        attribute: InsightAttribute,
         kType: KType
     ): Either<InsightClientError, Any?> = either {
-        when (value) {
-            is ObjectAttributeValue.Bool -> value.value
-            is ObjectAttributeValue.Date -> value.value
-            is ObjectAttributeValue.DateTime -> value.value
-            is ObjectAttributeValue.DoubleNumber -> value.value
-            is ObjectAttributeValue.Email -> value.value
-            is ObjectAttributeValue.Integer -> value.value
-            is ObjectAttributeValue.Ipaddress -> value.value
-            is ObjectAttributeValue.Text -> value.value
-            is ObjectAttributeValue.Textarea -> value.value
-            is ObjectAttributeValue.Time -> value.value
-            is ObjectAttributeValue.Url -> value.values
-            is ObjectAttributeValue.Select -> value.values// List<String>
+        when (attribute) {
+            is InsightAttribute.Bool -> attribute.value
+            is InsightAttribute.Date -> attribute.value
+            is InsightAttribute.DateTime -> attribute.value
+            is InsightAttribute.DoubleNumber -> attribute.value
+            is InsightAttribute.Email -> attribute.value
+            is InsightAttribute.Integer -> attribute.value
+            is InsightAttribute.Ipaddress -> attribute.value
+            is InsightAttribute.Text -> attribute.value
+            is InsightAttribute.Textarea -> attribute.value
+            is InsightAttribute.Time -> attribute.value
+            is InsightAttribute.Url -> attribute.values
+            is InsightAttribute.Select -> attribute.values// List<String>
             else -> InvalidArgumentInsightClientError(
                 "kType.classifier ${kType.classifier} is not supported."
             ).asEither<DomainType?>(

--- a/kotlin-insight-client/kotlin-insight-client-http/src/main/kotlin/com/linkedplanet/kotlininsightclient/http/model/HttpEditModel.kt
+++ b/kotlin-insight-client/kotlin-insight-client-http/src/main/kotlin/com/linkedplanet/kotlininsightclient/http/model/HttpEditModel.kt
@@ -20,7 +20,7 @@
 package com.linkedplanet.kotlininsightclient.http.model
 
 import com.linkedplanet.kotlininsightclient.api.model.InsightObject
-import com.linkedplanet.kotlininsightclient.api.model.ObjectAttributeValue
+import com.linkedplanet.kotlininsightclient.api.model.InsightAttribute
 import java.time.format.DateTimeFormatter
 
 // this is serialized and sent to insight, so it is not part of the model we control
@@ -36,35 +36,35 @@ internal fun InsightObject.toEditObjectItem() =
     )
 
 internal fun InsightObject.getEditAttributes(): List<ObjectEditItemAttribute> =
-    this.attributes.map { insightAttr ->
-        val values : List<Any?> = when (val attr = insightAttr.value) {
-            is ObjectAttributeValue.Text -> listOf(attr.value)
-            is ObjectAttributeValue.Integer -> listOf(attr.value)
-            is ObjectAttributeValue.Bool -> listOf(attr.value.toString())
-            is ObjectAttributeValue.Time -> listOfNotNull(attr.value?.format(DateTimeFormatter.ISO_TIME))
-            is ObjectAttributeValue.Date -> listOfNotNull(attr.value?.format(DateTimeFormatter.ISO_DATE))
-            is ObjectAttributeValue.DateTime -> listOfNotNull(attr.value?.format(DateTimeFormatter.ISO_ZONED_DATE_TIME))
-            is ObjectAttributeValue.DoubleNumber -> listOf(attr.value)
-            is ObjectAttributeValue.Email -> listOf(attr.value)
-            is ObjectAttributeValue.Ipaddress -> listOf(attr.value)
-            is ObjectAttributeValue.Textarea -> listOf(attr.value)
+    this.attributes.map { attr ->
+        val values : List<Any?> = when (attr) {
+            is InsightAttribute.Text -> listOf(attr.value)
+            is InsightAttribute.Integer -> listOf(attr.value)
+            is InsightAttribute.Bool -> listOf(attr.value.toString())
+            is InsightAttribute.Time -> listOfNotNull(attr.value?.format(DateTimeFormatter.ISO_TIME))
+            is InsightAttribute.Date -> listOfNotNull(attr.value?.format(DateTimeFormatter.ISO_DATE))
+            is InsightAttribute.DateTime -> listOfNotNull(attr.value?.format(DateTimeFormatter.ISO_ZONED_DATE_TIME))
+            is InsightAttribute.DoubleNumber -> listOf(attr.value)
+            is InsightAttribute.Email -> listOf(attr.value)
+            is InsightAttribute.Ipaddress -> listOf(attr.value)
+            is InsightAttribute.Textarea -> listOf(attr.value)
 
-            is ObjectAttributeValue.Url -> attr.values
-            is ObjectAttributeValue.Select -> attr.values
+            is InsightAttribute.Url -> attr.values
+            is InsightAttribute.Select -> attr.values
 
-            is ObjectAttributeValue.Reference -> attr.referencedObjects.map { it.id.raw }
-            is ObjectAttributeValue.User -> attr.users.map { it.key } //TODO: needs a test
+            is InsightAttribute.Reference -> attr.referencedObjects.map { it.id.raw }
+            is InsightAttribute.User -> attr.users.map { it.key } //TODO: needs a test
 
-            is ObjectAttributeValue.Group -> TODO()
-            is ObjectAttributeValue.Project -> TODO()
-            is ObjectAttributeValue.Status -> TODO()
-            is ObjectAttributeValue.Version -> TODO()
-            is ObjectAttributeValue.Confluence -> TODO()
-            is ObjectAttributeValue.Unknown -> TODO()
+            is InsightAttribute.Group -> TODO()
+            is InsightAttribute.Project -> TODO()
+            is InsightAttribute.Status -> TODO()
+            is InsightAttribute.Version -> TODO()
+            is InsightAttribute.Confluence -> TODO()
+            is InsightAttribute.Unknown -> TODO()
         }
 
         ObjectEditItemAttribute(
-            insightAttr.attributeId.raw,
+            attr.attributeId.raw,
             values.map { ObjectEditItemAttributeValue(it) }
         )
     }

--- a/kotlin-insight-client/kotlin-insight-client-test-base/src/main/kotlin/com/linkedplanet/kotlininsightclient/InsightObjectOperatorTest.kt
+++ b/kotlin-insight-client/kotlin-insight-client-test-base/src/main/kotlin/com/linkedplanet/kotlininsightclient/InsightObjectOperatorTest.kt
@@ -29,7 +29,7 @@ import com.linkedplanet.kotlininsightclient.api.model.InsightAttribute.Companion
 import com.linkedplanet.kotlininsightclient.api.model.InsightAttribute.Companion.toValue
 import com.linkedplanet.kotlininsightclient.api.model.InsightObjectId
 import com.linkedplanet.kotlininsightclient.api.model.InsightObjectTypeId
-import com.linkedplanet.kotlininsightclient.api.model.ObjectAttributeValue
+import com.linkedplanet.kotlininsightclient.api.model.InsightAttribute
 import com.linkedplanet.kotlininsightclient.api.model.ObjectTypeSchemaAttribute
 import com.linkedplanet.kotlininsightclient.api.model.addSelectValue
 import com.linkedplanet.kotlininsightclient.api.model.getAttributeByName
@@ -223,12 +223,12 @@ interface InsightObjectOperatorTest {
         assertThat(company.objectTypeName, equalTo("Company"))
         assertThat(company.objectTypeId, equalTo(InsightObjectTypeId(1)))
 
-        val created = company.getAttributeByName("Created")!!.value as ObjectAttributeValue.DateTime
+        val created = company.getAttributeByName("Created")!! as InsightAttribute.DateTime
 //        assertThat(created.value?.toInstant()?.toString(), equalTo("2022-10-27T09:15:53.212Z"))
         assertThat(created.value?.toInstant()?.toString(), endsWith(":15:53.212Z"))
         assertThat(created.value?.toInstant()?.toString(), startsWith("2022-10-27T"))
         assertThat(created.displayValue, equalTo("27/Oct/22 11:15 AM"))
-        val updated = company.getAttributeByName("Updated")!!.value as ObjectAttributeValue.DateTime
+        val updated = company.getAttributeByName("Updated")!! as InsightAttribute.DateTime
 //        assertThat(updated.value?.toInstant()?.toString(), equalTo("2023-02-21T07:10:25.993Z"))
         assertThat(updated.value?.toInstant()?.toString(), endsWith(":10:25.993Z"))
         assertThat(updated.value?.toInstant()?.toString(), startsWith("2023-02-21T"))

--- a/kotlin-insight-client/kotlin-insight-client-test-base/src/main/kotlin/com/linkedplanet/kotlininsightclient/repositories/CompanyRepositoryBasedOnNameMapping.kt
+++ b/kotlin-insight-client/kotlin-insight-client-test-base/src/main/kotlin/com/linkedplanet/kotlininsightclient/repositories/CompanyRepositoryBasedOnNameMapping.kt
@@ -31,7 +31,6 @@ import com.linkedplanet.kotlininsightclient.api.interfaces.identity
 import com.linkedplanet.kotlininsightclient.api.model.InsightAttribute
 import com.linkedplanet.kotlininsightclient.api.model.InsightObject
 import com.linkedplanet.kotlininsightclient.api.model.InsightObjectId
-import com.linkedplanet.kotlininsightclient.api.model.ObjectAttributeValue
 import com.linkedplanet.kotlininsightclient.api.model.ObjectTypeSchemaAttribute
 
 class CompanyRepositoryBasedOnNameMapping(

--- a/kotlin-insight-client/kotlin-insight-client-test-base/src/main/kotlin/com/linkedplanet/kotlininsightclient/repositories/CompanyRepositoryBasedOnNameMapping.kt
+++ b/kotlin-insight-client/kotlin-insight-client-test-base/src/main/kotlin/com/linkedplanet/kotlininsightclient/repositories/CompanyRepositoryBasedOnNameMapping.kt
@@ -28,10 +28,9 @@ import com.linkedplanet.kotlininsightclient.api.interfaces.InsightObjectOperator
 import com.linkedplanet.kotlininsightclient.api.interfaces.InsightObjectTypeOperator
 import com.linkedplanet.kotlininsightclient.api.interfaces.InsightSchemaOperator
 import com.linkedplanet.kotlininsightclient.api.interfaces.identity
-import com.linkedplanet.kotlininsightclient.api.model.InsightAttribute
 import com.linkedplanet.kotlininsightclient.api.model.InsightObject
 import com.linkedplanet.kotlininsightclient.api.model.InsightObjectId
-import com.linkedplanet.kotlininsightclient.api.model.ObjectAttributeValue
+import com.linkedplanet.kotlininsightclient.api.model.InsightAttribute
 import com.linkedplanet.kotlininsightclient.api.model.ObjectTypeSchemaAttribute
 
 class CompanyRepositoryBasedOnNameMapping(
@@ -48,7 +47,7 @@ class CompanyRepositoryBasedOnNameMapping(
         insightObjectOperator.getObjectByName(objectTypeId, domainObject.name, ::identity)
 
     override suspend fun referenceAttributeToValue(attribute: InsightAttribute): Any? {
-        val movie = (attribute.value as ObjectAttributeValue.Reference).referencedObjects.first().id
+        val movie = (attribute as InsightAttribute.Reference).referencedObjects.first().id
         val eitherMovie = countryOperator.getById(movie)
         return eitherMovie.orNull()
     }

--- a/kotlin-insight-client/kotlin-insight-client-test-base/src/main/kotlin/com/linkedplanet/kotlininsightclient/repositories/ObjectWithAllDefaultTypesRepository.kt
+++ b/kotlin-insight-client/kotlin-insight-client-test-base/src/main/kotlin/com/linkedplanet/kotlininsightclient/repositories/ObjectWithAllDefaultTypesRepository.kt
@@ -29,7 +29,6 @@ import com.linkedplanet.kotlininsightclient.api.error.InsightClientError
 import com.linkedplanet.kotlininsightclient.api.impl.AbstractInsightObjectRepository
 import com.linkedplanet.kotlininsightclient.api.interfaces.InsightObjectOperator
 import com.linkedplanet.kotlininsightclient.api.interfaces.identity
-import com.linkedplanet.kotlininsightclient.api.model.InsightAttribute
 import com.linkedplanet.kotlininsightclient.api.model.InsightAttribute.Companion.toEmailValue
 import com.linkedplanet.kotlininsightclient.api.model.InsightAttribute.Companion.toIpaddressValue
 import com.linkedplanet.kotlininsightclient.api.model.InsightAttribute.Companion.toSelectValues
@@ -38,9 +37,9 @@ import com.linkedplanet.kotlininsightclient.api.model.InsightAttribute.Companion
 import com.linkedplanet.kotlininsightclient.api.model.InsightAttribute.Companion.toValue
 import com.linkedplanet.kotlininsightclient.api.model.InsightObject
 import com.linkedplanet.kotlininsightclient.api.model.InsightObjectTypeId
-import com.linkedplanet.kotlininsightclient.api.model.ObjectAttributeValue
-import com.linkedplanet.kotlininsightclient.api.model.ObjectAttributeValue.Integer
-import com.linkedplanet.kotlininsightclient.api.model.ObjectAttributeValue.Text
+import com.linkedplanet.kotlininsightclient.api.model.InsightAttribute
+import com.linkedplanet.kotlininsightclient.api.model.InsightAttribute.Integer
+import com.linkedplanet.kotlininsightclient.api.model.InsightAttribute.Text
 import com.linkedplanet.kotlininsightclient.api.model.getAttributeValue
 
 class ObjectWithAllDefaultTypesRepository(
@@ -57,17 +56,17 @@ class ObjectWithAllDefaultTypesRepository(
             ObjectWithAllDefaultTypes(
                 id = insightObject.id,
                 name = insightObject.getAttributeValue<Text>(Name.attributeId)?.value!!,
-                testBoolean = insightObject.getAttributeValue<ObjectAttributeValue.Bool>(TestBoolean.attributeId)?.value,
+                testBoolean = insightObject.getAttributeValue<InsightAttribute.Bool>(TestBoolean.attributeId)?.value,
                 testInteger = insightObject.getAttributeValue<Integer>(TestInteger.attributeId)?.value,
-                testFloat = insightObject.getAttributeValue<ObjectAttributeValue.DoubleNumber>(TestFloat.attributeId)?.value,
-                testDate = insightObject.getAttributeValue<ObjectAttributeValue.Date>(TestDate.attributeId)?.value,
-                testDateTime = insightObject.getAttributeValue<ObjectAttributeValue.DateTime>(TestDateTime.attributeId)?.value,
-                testUrl = insightObject.getAttributeValue<ObjectAttributeValue.Url>(TestUrl.attributeId)?.values?.toSet() ?: emptySet(),
-                testEmail = insightObject.getAttributeValue<ObjectAttributeValue.Email>(TestEmail.attributeId)?.value,
-                testTextArea = insightObject.getAttributeValue<ObjectAttributeValue.Textarea>(TestTextArea.attributeId)?.value,
-                testSelect = insightObject.getAttributeValue<ObjectAttributeValue.Select>(TestSelect.attributeId)?.values
+                testFloat = insightObject.getAttributeValue<InsightAttribute.DoubleNumber>(TestFloat.attributeId)?.value,
+                testDate = insightObject.getAttributeValue<InsightAttribute.Date>(TestDate.attributeId)?.value,
+                testDateTime = insightObject.getAttributeValue<InsightAttribute.DateTime>(TestDateTime.attributeId)?.value,
+                testUrl = insightObject.getAttributeValue<InsightAttribute.Url>(TestUrl.attributeId)?.values?.toSet() ?: emptySet(),
+                testEmail = insightObject.getAttributeValue<InsightAttribute.Email>(TestEmail.attributeId)?.value,
+                testTextArea = insightObject.getAttributeValue<InsightAttribute.Textarea>(TestTextArea.attributeId)?.value,
+                testSelect = insightObject.getAttributeValue<InsightAttribute.Select>(TestSelect.attributeId)?.values
                     ?: emptyList(),
-                testIpAddress = insightObject.getAttributeValue<ObjectAttributeValue.Ipaddress>(TestIpAddress.attributeId)?.value,
+                testIpAddress = insightObject.getAttributeValue<InsightAttribute.Ipaddress>(TestIpAddress.attributeId)?.value,
             )
         }
 

--- a/kotlin-insight-client/kotlin-insight-client-test-base/src/main/kotlin/com/linkedplanet/kotlininsightclient/repositories/TestsWithListRepositoryBasedOnNameMapping.kt
+++ b/kotlin-insight-client/kotlin-insight-client-test-base/src/main/kotlin/com/linkedplanet/kotlininsightclient/repositories/TestsWithListRepositoryBasedOnNameMapping.kt
@@ -28,10 +28,9 @@ import com.linkedplanet.kotlininsightclient.api.interfaces.InsightObjectOperator
 import com.linkedplanet.kotlininsightclient.api.interfaces.InsightObjectTypeOperator
 import com.linkedplanet.kotlininsightclient.api.interfaces.InsightSchemaOperator
 import com.linkedplanet.kotlininsightclient.api.interfaces.identity
-import com.linkedplanet.kotlininsightclient.api.model.InsightAttribute
 import com.linkedplanet.kotlininsightclient.api.model.InsightObject
 import com.linkedplanet.kotlininsightclient.api.model.InsightObjectId
-import com.linkedplanet.kotlininsightclient.api.model.ObjectAttributeValue
+import com.linkedplanet.kotlininsightclient.api.model.InsightAttribute
 import com.linkedplanet.kotlininsightclient.api.model.ObjectTypeSchemaAttribute
 import com.linkedplanet.kotlininsightclient.orFail
 
@@ -49,7 +48,7 @@ class TestsWithListRepositoryBasedOnNameMapping(
         insightObjectOperator.getObjectByName(objectTypeId, domainObject.name, ::identity)
 
     override suspend fun referenceAttributeToValue(attribute: InsightAttribute): Any? {
-        val listOfObjects = (attribute.value as? ObjectAttributeValue.Reference)?.referencedObjects
+        val listOfObjects = (attribute as? InsightAttribute.Reference)?.referencedObjects
             ?.mapNotNull { simpleObjectRepository.getById(it.id).orNull() }
         return listOfObjects
     }


### PR DESCRIPTION
syntax was weird, when one had to access values like attribute.value.value